### PR TITLE
New label positions

### DIFF
--- a/example.py
+++ b/example.py
@@ -6,12 +6,12 @@ import tskit_arg_visualizer
 # Generate a random tree sequence with record_full_arg=True so that you get marked recombination nodes
 ts_rs = random.randint(0,10000)   
 ts = msprime.sim_ancestry(
-    samples=2,
+    samples=5,
     recombination_rate=1e-8,
     sequence_length=3_000,
     population_size=10_000,
     record_full_arg=True,
-    random_seed=1
+    random_seed=ts_rs
 )
 print(ts_rs)
 
@@ -33,7 +33,7 @@ print(ts_rs)
 #ts = tskit.load("/Users/jameskitchens/Documents/GitHub/sparg2.0/ARGweaver/slim/condensed.trees")
 
 d3arg = tskit_arg_visualizer.D3ARG(ts=ts)
-d3arg.draw(width=500, height=500, y_axis_labels=True, y_axis_scale="rank", tree_highlighting=True, edge_type="ortho")
+d3arg.draw(width=500, height=500, y_axis_labels=True, y_axis_scale="rank", tree_highlighting=True, edge_type="line")
 
 
 # Or draw from a previously saved tree sequence which is stored in a JSON file

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -120,24 +120,32 @@ class D3ARG:
         unique_times = list(np.unique(ts.tables.nodes.time)) # Determines the rank (y position) of each time point 
         nodes = []
         for ID, node in enumerate(ts.tables.nodes):
+            child_of = list(np.unique(ts.tables.edges[np.where(ts.tables.edges.child == ID)[0]].parent))
+            for i,child in enumerate(child_of):
+                if child in recombination_nodes_to_merge:
+                    child_of[i] -= 1
+            parent_of = list(np.unique(ts.tables.edges[np.where(ts.tables.edges.parent == ID)[0]].child))
+            for i,parent in enumerate(parent_of):
+                if parent in recombination_nodes_to_merge:
+                    parent_of[i] -= 1
             info = {
                 "id": ID,
                 "flag": node.flags,
                 "time": node.time,
                 "time_01":1-node.time/ts.max_root_time,
                 "logtime_01":1-math.log(node.time+1)/math.log(ts.max_root_time),
-                "rank_01": 1-(unique_times.index(node.time)*h_spacing) #fixed y position, property of force layout
+                "rank_01": 1-(unique_times.index(node.time)*h_spacing), #fixed y position, property of force layout
+                "child_of": list(np.unique(child_of)),
+                "parent_of": list(np.unique(parent_of))
             }
             label = ID
             if node.flags == 131072:
                 if ID in recombination_nodes_to_merge:
                     continue
                 label = str(ID)+"/"+str(ID+1)
-                parent_of = ts.tables.edges[np.where(ts.tables.edges.parent == ID)[0]]
-                if len(parent_of) > 0:
-                    info["x_pos_reference"] = parent_of.child[0]
+                info["x_pos_reference"] = parent_of[0]
             elif node.flags == 262144:
-                info["x_pos_reference"] = ts.tables.edges[np.where(ts.tables.edges.parent == ID)[0]].child[0]
+                info["x_pos_reference"] = parent_of[0]
             info["label"] = label #label which is either the node ID or two node IDs for recombination nodes
             if node.flags == 1:
                 info["fx_01"] = ordered_nodes.index(ID)*w_spacing #sample nodes have a fixed x position

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -132,6 +132,12 @@ function draw_force_diagram() {
                 return "hiddennode"
             }
         })
+        .attr("parents", function(d) {
+            return d.child_of.toString().replace(",", " ")
+        })
+        .attr("children", function(d) {
+            return d.parent_of.toString().replace(",", " ")
+        })
         .attr("r", 7)
         .call(
             d3
@@ -407,14 +413,25 @@ function draw_force_diagram() {
 
         label
             .attr("x", function(d) {
-                if (d.flag == 131072) {
+                if (d.flag == 131072 || d.parent_of.length == 0 || d.child_of.length == 0) {
                     return d.x;
+                } else if (d.child_of.length == 1) {
+                    var parent_x = document.getElementById(String($divnum) + "_node" + d.child_of[0]).getAttribute("cx");
+                    if (parent_x > d.x) {
+                        return d.x - 15
+                    } else {
+                        return d.x + 15
+                    }
                 } else {
                     return d.x + 15;
                 }
             })
             .attr("y", function(d) {
-                return d.y - 15;
+                if (d.parent_of.length == 0) {
+                    return d.y + 25;
+                } else {
+                    return d.y - 15;
+                }
             });
     }
 
@@ -458,11 +475,8 @@ function draw_force_diagram() {
                 var highlight_links = d3.select("#arg_${divnum} .links")
                     .selectAll("g")
                         .filter(function(j) {
-                            console.log(j);
-                            console.log(d);
                             return j.right > d.start & j.left < d.stop;
                         });
-                console.log(highlight_links);
                 highlight_links.raise();
                 highlight_links
                     .select(".link")


### PR DESCRIPTION
Nodes JSON now includes child_of and parent_of. These make it straightforward to calculate how many parents/children each node has and position labels accordingly. Nodes without children (tips) have labels directly underneath. The positions of coalescent nodes labels will shift sides (left or right) of the node depending on the location of the parent. Recombination nodes are treated as a single node (consistent with the usual workflow for this viz). There may be a more elegant way of doing this since technically parents/children are stored within the links JSON, but for simple cases, this redundant info doesn't seem too bad.