### PR TITLE
Add sequence length endpoints

### DIFF
--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ print(ts_rs)
 #ts = tskit.load("/Users/jameskitchens/Documents/GitHub/sparg2.0/ARGweaver/slim/condensed.trees")
 
 d3arg = tskit_arg_visualizer.D3ARG(ts=ts)
-d3arg.draw(width=500, height=500, y_axis_labels=True, y_axis_scale="rank", tree_highlighting=True, edge_type="line")
+d3arg.draw(width=500, height=500, y_axis_labels=True, y_axis_scale="rank", tree_highlighting=True, edge_type="ortho")
 
 
 # Or draw from a previously saved tree sequence which is stored in a JSON file

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -301,7 +301,7 @@ class D3ARG:
             transformed_nodes.append(node)
         y_axis_text = [round(t) for t in set(y_axis_text)]
         if tree_highlighting:
-            height += 50
+            height += 75
         transformed_bps = []
         for bp in self.breakpoints:
             if y_axis_labels:

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -102,15 +102,17 @@
     fill: none;
 }
 
-.label {
+.labels {
     text-anchor: middle;
+}
+
+.label {
     fill: #053e4e;
     font-family: Arial;
     font-size: 12px;
 }
 
 .hiddenlabel {
-    text-anchor: middle;
     fill: lightgrey;
     font-family: Arial;
     font-size: 12px;

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -445,7 +445,11 @@ function draw_force_diagram() {
     }
 
     if ($tree_highlighting) {
-        svg.append("g")
+        
+        var th_group = svg.append("g").attr("class", "tree_highlighting");
+        
+        th_group
+            .append("g")
             .attr("class", "breakpoints")
             .selectAll("rect")
             .data(graph.breakpoints)
@@ -460,7 +464,7 @@ function draw_force_diagram() {
             .attr("x", function(d) {
                 return d.x_pos;
             })
-            .attr("y", $height-50)
+            .attr("y", $height-55)
             .attr("width", function(d) {
                 return d.width;
             })
@@ -491,6 +495,24 @@ function draw_force_diagram() {
                     .style("stroke", "#053e4e")
                     .style("stroke-width", 3);
             });
+        
+        var endpoints = th_group.append("g").attr("class", "endpoints");
+        
+        endpoints
+            .append("text")
+                .attr("class", "label")
+                .style("text-anchor", "start")
+                .text(graph.breakpoints[0].start)
+                .attr("x", graph.breakpoints[0].x_pos)
+                .attr("y", $height);
+        
+        endpoints
+            .append("text")
+                .attr("class", "label")
+                .style("text-anchor", "end")
+                .text(graph.breakpoints[graph.breakpoints.length-1].stop)
+                .attr("x", $width)
+                .attr("y", $height);
     }
 }
 


### PR DESCRIPTION
Adding labels to each of the breakpoints gets cluttered but providing the endpoints seems like a good way of getting across the sequence length included in the ARG. I may add a popup when you highlight a breakpoint that specifies the bounds of that region. I still haven't looked into what to do when the regions are so small that they are pretty much invisible.