### PR TITLE
Wait until require is available before running

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -38,18 +38,6 @@ d3arg = tskit_arg_visualizer.D3ARG.from_json(json=arg_json)
 
 ## Plotting
 
-<blockquote>
-**_Plotting In Jupyter Notebooks:_** Sometimes Jupyter does not succeed in loading the require.js header, in which case the visualization may appear blank. If so, you can add the header using the following code in a new cell:
-
-```
-%%javascript
-var script = document.createElement('script');
-script.type = 'text/javascript';
-script.src = 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js';
-document.head.appendChild(script);
-```
-</blockquote>
-
 There are currently three plotting methods: `draw()`, `draw_node()`, and `draw_genome_bar()`.
 
 ### `draw()`

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -96,7 +96,7 @@ def draw_D3(arg_json, force_notebook=False):
     else:
         with tempfile.NamedTemporaryFile("w", delete=False, suffix=".html") as f:
             url = "file://" + f.name
-            f.write("<!DOCTYPE html><html><head><meta charset='utf-8'><style>"+styles+"</style><script src='https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js'></script></head><body>" + html + "</body></html>")
+            f.write("<!DOCTYPE html><html><head><meta charset='utf-8'><style>"+styles+"</style></head><body>" + html + "</body></html>")
         webbrowser.open(url, new=2)
 
 class D3ARG:

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -1,10 +1,28 @@
-require.config({ 
-    paths: { 
-        d3: 'https://d3js.org/d3.v7.min'
+function ensureRequire() {
+    // Needed e.g. in Jupyter notebooks: if require is already available, return resolved promise
+    if (typeof require !== 'undefined') {
+        return Promise.resolve(require);
     }
-});
 
-require(["d3"], function(d3) {
+    // Otherwise, dynamically load require.js
+    return new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js';
+        script.onload = () => resolve(require);
+        script.onerror = reject;
+        document.head.appendChild(script);
+    });
+};
+
+ensureRequire()
+    .then(require => {
+        require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
+        require(["d3"], main_visualizer);
+    })
+    .catch(err => console.error('Failed to load require.js:', err));
+
+
+function main_visualizer(d3) {
     /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
     
     function download (url, name, opts) {
@@ -1065,4 +1083,4 @@ require(["d3"], function(d3) {
     }
 
     draw_force_diagram()
-})
+}


### PR DESCRIPTION
Suggested by Ben Jeffery, and should fix the need for bespoke JS in a notebook. I think it means we don't need to include it in the plain HTML output either, so I've removed the <script> embedding from the python code, so that the require.js URL is only specified once in the codebase