### PR TITLE
Rework templating

### DIFF
--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -28,14 +28,14 @@ def get_css_and_js():
 def viz_html(arg_json=None, css_and_js=None):
     html = ""
     if arg_json is not None:
-        html += "<div id='arg_{n}' class='d3arg' style='min-width:{w}px;min-height:{h}px;'></div>".format(
+        html = "<div id='arg_{n}' class='d3arg' style='min-width:{w}px;min-height:{h}px;'></div>".format(
             n=arg_json['divnum'],
             w=arg_json['width']+40,
             h=arg_json['height']+80,
         )
-    html += "<script>ensureRequire()"
+    js = "ensureRequire()"
     if css_and_js is not None:
-        html += """
+        js += """
         .then(
           require => {
             // Add CSS
@@ -55,7 +55,7 @@ def viz_html(arg_json=None, css_and_js=None):
           })""" % css_and_js
     # Pass in the template variables from arg_json to the javascript functions below
     if arg_json is not None:
-        html += Template("""
+        js += Template("""
         .then(
           require => {
             require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
@@ -63,8 +63,8 @@ def viz_html(arg_json=None, css_and_js=None):
               main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $include_mutation_labels, $tree_highlighting, "$title", $rotate_tip_labels, "$plot_type", "$source")
             });
           })""").safe_substitute(arg_json)
-    html += ".catch(err => console.error('Failed to load require.js:', err));</script>"
-    return html
+    js += ".catch(err => console.error('Failed to load require.js:', err));"
+    return f"{html}<script>{js}</script>"
 
 
 def call_d3arg_javascript(arg_json, whole_page=True, inject_header=False):

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -68,11 +68,11 @@ def viz_html(arg_json=None, css_and_js=None):
 
 
 def call_d3arg_javascript(arg_json, whole_page=True, inject_header=False):
-    """
-    Returns the JavaScript code to load the D3ARG visualizer.
-    If include_header is True, the code will add javascript to
-    insert the header css and js required for the visualizer.
-    """ 
+    # Internal code to create the JavaScript code to load the D3ARG visualizer.
+    # If whole_page is True, the code will return a full html document with the
+    # visualizer embedded in it. If inject_header is True, the code will add
+    # javascript to inject the static css and js required for the visualizer
+    # into the html document header (and whole_page is ignored).
     if inject_header:
         html = viz_html(arg_json, get_css_and_js())
     else:

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -58,7 +58,7 @@
 }
 
 .d3arg .dashboard .activecolor:active path {
-    fill: #1eebb1;
+    fill: var( --TskitArgvizHighlightCol);
 }
 
 .d3arg .savemethods, .d3arg .labelmethods {
@@ -78,7 +78,7 @@
 }
 
 .d3arg .savemethods button:hover, .d3arg .labelmethods button:hover {
-    color: #1eebb1;
+    color: var( --TskitArgvizHighlightCol);
 }
 
 .d3arg .labelmethods button.node-labels-default {

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -1,3 +1,7 @@
+:root {
+    --TskitArgvizHighlightCol: #1eebb1;
+}
+
 .d3arg {
     position: relative;
     display: flex;

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -1,11 +1,13 @@
-/* See __init__.py for how to call the main_visualizer after ensureRequire(). */
+/* See __init__.py for how to call the main_visualizer after ensureRequire(). 
+ * NB: you must avoid using backtinks in this file, as when used in a notebook
+* it can get templated into a javascript call then injected into the head of a document
+*/
 
 function ensureRequire() {
     // Needed e.g. in Jupyter notebooks: if require is already available, return resolved promise
     if (typeof require !== 'undefined') {
         return Promise.resolve(require);
     }
-
     // Otherwise, dynamically load require.js
     return new Promise((resolve, reject) => {
         const script = document.createElement('script');
@@ -35,10 +37,10 @@ function main_visualizer(
 
     function check_styles_loaded() {
         const bodyStyles = window.getComputedStyle(document.body);
-        if bodyStyles.getPropertyValue('--TskitArgvizHighlightCol') {
+        if (bodyStyles.getPropertyValue('--TskitArgvizHighlightCol')) {
             /* stylesheet already loaded, nothing to do */
         } else {
-            alert("Styles not loaded: if running in a notebook, please call `tskit_arg_visualizer.setup()")
+            alert("Styles not loaded: if running in a notebook, please call 'tskit_arg_visualizer.setup()'")
         }
     }
 
@@ -67,7 +69,7 @@ function main_visualizer(
         return xhr.status >= 200 && xhr.status <= 299
     }
     
-    // `a.click()` doesn't work for all browsers (#465)
+    // 'a.click()' doesn't work for all browsers (#465)
     function click (node) {
         try {
             node.dispatchEvent(new MouseEvent('click'))

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -1,3 +1,5 @@
+/* See __init__.py for how to call the main_visualizer after ensureRequire(). */
+
 function ensureRequire() {
     // Needed e.g. in Jupyter notebooks: if require is already available, return resolved promise
     if (typeof require !== 'undefined') {
@@ -1254,17 +1256,4 @@ function main_visualizer(
 
     draw_force_diagram()
 }
-
-/* NB: the code below fires up the visualizer: templates in this call
-    can be used to pass in the appropriate data
-*/
-
-ensureRequire()
-    .then(require => {
-        require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
-        require(["d3"], function(d3) {
-            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $include_mutation_labels, $tree_highlighting, "$title", $rotate_tip_labels, "$plot_type", "$source")
-        });
-    })
-    .catch(err => console.error('Failed to load require.js:', err));
 

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -32,8 +32,18 @@ function main_visualizer(
     plot_type,
     source
 ) {
+
+    function check_styles_loaded() {
+        const bodyStyles = window.getComputedStyle(document.body);
+        if bodyStyles.getPropertyValue('--TskitArgvizHighlightCol') {
+            /* stylesheet already loaded, nothing to do */
+        } else {
+            alert("Styles not loaded: if running in a notebook, please call `tskit_arg_visualizer.setup()")
+        }
+    }
+
+
     /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
-    
     function download (url, name, opts) {
         var xhr = new XMLHttpRequest()
         xhr.open('GET', url)
@@ -1254,6 +1264,7 @@ function main_visualizer(
         }
     }
 
+    check_styles_loaded()
     draw_force_diagram()
 }
 


### PR DESCRIPTION
Stacked on #145 for ease of removing the `divnum` templated variable.

This is quite a large rejigging of the code, but it seems to work for me in a notebook. It uses the hack in #39 to only place the styles and static js into a notebook once. The JS templating has been restricted to a small javascript snippet which I have moved to the top of `__init__.py` rather than keep in `visualizer.js` (but we could put it into a standalone separate JS file, I guess?

Is this what you had in mind @kitchensjn ?