### PR TITLE
Position labels

### DIFF
--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -955,7 +955,7 @@ class D3ARG:
             "width":width,
             "height":height,
             "y_axis":{
-                "include_labels":str(y_axis_labels).lower(),
+                "include_labels":str(bool(y_axis_labels)).lower(),
                 "ticks":sorted(list(set(y_axis_ticks)), reverse=True),
                 "text":sorted(list(y_axis_text)),
                 "max_min":[max(y_axis_ticks),min(y_axis_ticks)],
@@ -963,14 +963,14 @@ class D3ARG:
             },
             "edges":{
                 "type":edge_type,
-                "variable_width":str(variable_edge_width).lower(),
-                "include_underlink":str(include_underlink).lower()
+                "variable_width":str(bool(variable_edge_width)).lower(),
+                "include_underlink":str(bool(include_underlink)).lower()
             },
-            "condense_mutations":str(condense_mutations).lower(),
-            "include_mutation_labels":str(include_mutation_labels).lower(),
-            "tree_highlighting":str(tree_highlighting).lower(),
+            "condense_mutations":str(bool(condense_mutations)).lower(),
+            "include_mutation_labels":str(bool(include_mutation_labels)).lower(),
+            "tree_highlighting":str(bool(tree_highlighting)).lower(),
             "title":str(title),
-            "rotate_tip_labels":str(rotate_tip_labels).lower(),
+            "rotate_tip_labels":str(bool(rotate_tip_labels)).lower(),
             "plot_type":plot_type
         }
         return arg

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -12,12 +12,12 @@
     visibility: visible;
 }
 
-.dashboard {
+.d3arg .dashboard {
     display: flex;
     visibility: hidden;
 }
 
-.dashboard .dashbutton {
+.d3arg .dashboard .dashbutton {
     position: relative;
     font-size: 30px;
     border: 0px;
@@ -26,7 +26,7 @@
     height: 30px;
 }
 
-.dashboard .dashbutton .tip {
+.d3arg .dashboard .dashbutton .tip {
     width: 150px;
     font-size: 12px;
     background-color: lightgrey;
@@ -41,23 +41,23 @@
     visibility: hidden;
 }
 
-.dashboard .dashbutton:hover .desc {
+.d3arg .dashboard .dashbutton:hover .desc {
     visibility: visible;
 }
 
-.dashboard path {
+.d3arg .dashboard path {
     fill: grey;
 }
 
-.dashboard .dashbutton:hover path {
+.d3arg .dashboard .dashbutton:hover path {
     fill: #053e4e;
 }
 
-.dashboard .activecolor:active path {
+.d3arg .dashboard .activecolor:active path {
     fill: #1eebb1;
 }
 
-.savemethods, .labelmethods {
+.d3arg .savemethods, .d3arg .labelmethods {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -65,7 +65,7 @@
     flex-wrap: wrap;
 }
 
-.savemethods button, .labelmethods button {
+.d3arg .savemethods button, .d3arg .labelmethods button {
     background-color: lightgrey;
     color: #053e4e;
     font-size: 12px;
@@ -73,87 +73,87 @@
     border: none;
 }
 
-.savemethods button:hover, .labelmethods button:hover {
+.d3arg .savemethods button:hover, .d3arg .labelmethods button:hover {
     color: #1eebb1;
 }
 
-.labelmethods button.node-labels-default {
+.d3arg .labelmethods button.node-labels-default {
     text-decoration: underline;
 }
 
-.yaxis path {
+.d3arg .yaxis path {
     stroke: #053e4e;
     stroke-width: 3px;
 }
 
-.yaxis line {
+.d3arg .yaxis line {
     stroke: #053e4e;
     stroke-width: 3px;
 }
 
-.yaxis text {
+.d3arg .yaxis text {
     fill: #053e4e;
     stroke: 1px;
 }
 
-.hiddennode {
+.d3arg .hiddennode {
     fill: lightgrey;
     stroke: lightgrey;
     stroke-width: 4px;
 }
 
-.underlink {
+.d3arg .underlink {
     stroke: #ffffff;
     stroke-width: 12px;
     fill: none;
 }
 
-.link {
+.d3arg .link {
     stroke-width: 4px;
     fill: none;
 }
 
-.hiddenlink {
+.d3arg .hiddenlink {
     stroke: lightgrey;
     stroke-width: 4px;
     fill: none;
 }
 
-.labels {
+.d3arg .labels {
     text-anchor: middle;
 }
 
-.label {
+.d3arg .label {
     fill: #053e4e;
     font-family: Arial;
     font-size: 12px;
 }
 
-.hiddenlabel {
+.d3arg .hiddenlabel {
     fill: lightgrey;
     font-family: Arial;
     font-size: 12px;
 }
 
-svg {
+.d3arg svg {
     display: block;
 }
 
-button {
+.d3arg button {
     display: block;
     cursor: pointer;
 }
 
-.saving {
+.d3arg .saving {
     display: flex;
     flex-direction: row;
 }
 
-.saving .message {
+.d3arg .saving .message {
     display: none;
 }
 
-.tooltip {
+.d3arg .tooltip {
     position: absolute;
     max-width: 500px;
     padding: 10px;

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -162,3 +162,7 @@
     text-align: center;
     z-index: 9999;
 }
+
+.d3arg .sites text {
+    text-anchor: middle;
+}

--- a/tskit_arg_visualizer/visualizer.css
+++ b/tskit_arg_visualizer/visualizer.css
@@ -129,6 +129,14 @@
     font-size: 12px;
 }
 
+.d3arg .label.start {
+    text-anchor: start;
+}
+
+.d3arg .label.stop {
+    text-anchor: end;
+}
+
 .d3arg .hiddenlabel {
     fill: lightgrey;
     font-family: Arial;

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -396,7 +396,7 @@ function main_visualizer(d3) {
                                 });
                             })
                             .style('fill', '#1eebb1');
-                    d3.selectAll("#arg_${divnum} .mutations .e" + d.id).style("display", "block");
+                    d3.selectAll("#arg_${divnum} .sites .e" + d.id).style("display", "block");
                 })
                 .on('mouseout', function (event, d) {
                     d3.select(this)
@@ -404,8 +404,7 @@ function main_visualizer(d3) {
                         .style("cursor", "default");
                     d3.select("#arg_${divnum} .breakpoints").selectAll(".included")
                         .style("fill", d.fill);
-                    d3.selectAll("#arg_${divnum} .mutations .e" + d.id).style("display", "none");
-
+                    d3.selectAll("#arg_${divnum} .sites .e" + d.id).style("display", "none");
                 });
         }
 
@@ -511,7 +510,7 @@ function main_visualizer(d3) {
                     .style("cursor", "pointer")
                     .selectAll("rect")
                         .style("stroke", i.fill);
-                d3.select("#arg_${divnum} .mutations .s" + i.site_id).style("display", "block");
+                d3.select("#arg_${divnum} .sites .s" + i.site_id).style("display", "block");
                 var rect = d3.select("#arg_${divnum}").node().getBoundingClientRect();
                 tip
                     .style("display", "block")
@@ -528,7 +527,7 @@ function main_visualizer(d3) {
                         .selectAll("rect")
                             .style("stroke", i.stroke)
                             .style("fill", i.fill);
-                    d3.select("#arg_${divnum} .mutations .s" + i.site_id).style("display", "none");
+                    d3.select("#arg_${divnum} .sites .s" + i.site_id).style("display", "none");
                     tip.style("display", "none");
                 }
             });
@@ -1094,39 +1093,53 @@ function main_visualizer(d3) {
                     .attr("x", $width)
                     .attr("y", $height-5);
 
-            var mut_pos = th_group
+            var site_pos = th_group
                 .append("g")
-                .attr("class", "mutations")
+                .attr("class", "sites")
                 .selectAll("line")
                 .data(graph.mutations)
                 .enter()
                 .append("g")
                 .attr("class", function(d) {return "s" + d.site_id + " e" + d.edge;})
                 .style("display", "none");
-        
-            mut_pos
+
+            function createSiteLine(selection) {
+                return selection
+                    .append("line")
+                    .attr("y1", $height-60-5)
+                    .attr("y2", $height-60+40+5)
+                    .style("stroke-width", 3)
+                    .style("fill", "none");
+            }
+                  
+            function createSiteText(selection) {
+                return selection
+                    .append("text")
+                    .attr("y", $height-60-8)
+                    .attr("class", "label")
+            }
+                  
+            site_pos
                 .each(function(d) {
                     if (typeof(d.x_pos) == "object") {
-                        d3.select(this).selectAll("line").data(d.x_pos)
-                            .enter()
-                            .append("line")
-                            .attr("x1", function(x) { return x; })
-                            .attr("y1", $height-60-5)
-                            .attr("x2", function(x) { return x; })
-                            .attr("y2", $height-60+40+5)
-                            .style("stroke-width", 3)
-                            .style("stroke", d.fill)
-                            .style("fill", "none");
+                        /* d.x_pos is an array of x_pos values */
+                        const select = d3.select(this).selectAll("line").data(d.x_pos).enter();
+                        createSiteLine(select)
+                            .attr("x1", x => x)
+                            .attr("x2", x => x)
+                            .style("stroke", d.fill);
+                        createSiteText(select)
+                            .attr("x", x => x)
+                            .text((_, i) => String(d.position[i]));
                     } else {
-                        d3.select(this)
-                            .append("line")
+                        const select = d3.select(this);
+                        createSiteLine(select)
                             .attr("x1", d.x_pos)
-                            .attr("y1", $height-60-5)
                             .attr("x2", d.x_pos)
-                            .attr("y2", $height-60+40+5)
-                            .style("stroke-width", 3)
-                            .style("stroke", d.fill)
-                            .style("fill", "none");
+                            .style("stroke", d.fill);
+                        createSiteText(select)
+                            .attr("x", d.x_pos)
+                            .text(String(d.position));
                     }
                 });
             

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -387,23 +387,45 @@ function main_visualizer(d3) {
                     d3.select(this)
                         .style('stroke', '#1eebb1')
                         .style("cursor", "pointer");
-                    d3.select("#arg_${divnum} .breakpoints")
-                        .selectAll(".included")
-                            .filter(function(j) {
-                                return d.bounds.split(" ").some(function(region) {
-                                    region = region.split("-");
-                                    return (parseFloat(region[0]) <= j.start) & (parseFloat(region[1]) >= j.stop)
-                                });
-                            })
-                            .style('fill', '#1eebb1');
                     d3.selectAll("#arg_${divnum} .sites .e" + d.id).style("display", "block");
+                    d3.selectAll("#arg_${divnum} .endpoints")
+                        .style('display', 'none'); /* hide other labels to avoid clashes */
+                    const bars = d3.select("#arg_${divnum} .breakpoints").selectAll(".included");
+                    bars /* colour in all bars covered by these bounds */
+                        .filter(function(j) {
+                            return d.bounds.split(" ").some(function(region) {
+                                region = region.split("-");
+                                return (parseFloat(region[0]) <= j.start) & (parseFloat(region[1]) >= j.stop)
+                            });
+                        })
+                        .selectAll("rect").style('fill', '#1eebb1');
+                    bars /* show the leftmost position label */
+                        .filter(function(j) {
+                            return d.bounds.split(" ").some(function(region) {
+                                region = region.split("-");
+                                return (parseFloat(region[0]) == j.start)
+                            });
+                        })
+                        .selectAll("text.start").style('display', 'block');
+                    bars /* show the rightmost position label */
+                        .filter(function(j) {
+                            return d.bounds.split(" ").some(function(region) {
+                                region = region.split("-");
+                                return (parseFloat(region[1]) == j.stop)
+                            });
+                        })
+                        .selectAll("text.stop").style('display', 'block');
+
                 })
                 .on('mouseout', function (event, d) {
                     d3.select(this)
                         .style('stroke', d.stroke)
                         .style("cursor", "default");
-                    d3.select("#arg_${divnum} .breakpoints").selectAll(".included")
-                        .style("fill", d.fill);
+                    const bars = d3.select("#arg_${divnum} .breakpoints").selectAll(".included");
+                    bars.selectAll("rect").style("fill", d.fill);
+                    bars.selectAll("text").style("display", "none");
+                    d3.selectAll("#arg_${divnum} .endpoints")
+                        .style('display', 'block');
                     d3.selectAll("#arg_${divnum} .sites .e" + d.id).style("display", "none");
                 });
         }
@@ -1009,46 +1031,53 @@ function main_visualizer(d3) {
             
             var th_group = svg.append("g").attr("class", "tree_highlighting");
             
-            th_group
+            var breakpoint_regions = th_group
                 .append("g")
                 .attr("class", "breakpoints")
-                .selectAll("rect")
+                .selectAll("g")
                 .data(graph.breakpoints)
                 .enter()
+                .append("g")
+                .attr("class", d => eval(d.included) ? "included" : null)
+                .attr("start", d => d.start)
+                .attr("stop", d => d.stop);
+
+            breakpoint_regions
                 .append("rect")
-                .attr("class", function(d) {
-                    if (eval(d.included)) {
-                        return "included";
-                    }
-                })
-                .attr("start", function(d) {
-                    return d.start;
-                })
-                .attr("stop", function(d) {
-                    return d.stop;
-                })
-                .attr("x", function(d) {
-                    return d.x_pos;
-                })
+                .attr("x", d => d.x_pos)
                 .attr("y", $height-60)
-                .attr("width", function(d) {
-                    return d.width;
-                })
+                .attr("width", d => d.width)
                 .attr("height", 40)
                 .attr("stroke", "#FFFFFF")
                 .attr("stroke-width", 1)
-                .attr("fill", function(d) {
-                    if (eval(d.included)) {
-                        return d.fill;
-                    } else {
-                        return "gray";
-                    }
-                })
+                .attr("fill", d => eval(d.included) ? d.fill : "gray");
+
+            breakpoint_regions
+                .append("text")
+                .attr("x", d => d.x_pos)
+                .attr("y", $height-5)
+                .attr("class", "label start")
+                .style("display", "none")
+                .text(d => String(d.start));
+
+            breakpoint_regions
+                .append("text")
+                .attr("x", d => d.x_pos + d.width)
+                .attr("y", $height-5)
+                .attr("class", "label stop")
+                .style("display", "none")
+                .text(d => String(d.stop));
+
+            breakpoint_regions
                 .on('mouseover', function (event, d) {
                     if (eval(d.included)) {
-                        d3.select(this)
+                        d3.select(this).selectAll("rect")
                             .style('fill', '#1eebb1')
                             .style("cursor", "pointer");
+                        d3.select(this).selectAll("text")
+                            .style('display', 'block');
+                        d3.selectAll("#arg_${divnum} .endpoints")
+                            .style('display', 'none'); /* hide other labels to avoid clashes */
                         var highlight_links = d3.select("#arg_${divnum} .links")
                             .selectAll("g")
                                 .filter(function(j) {
@@ -1065,9 +1094,13 @@ function main_visualizer(d3) {
                 })
                 .on('mouseout', function (event, d) {
                     if (eval(d.included)) {
-                        d3.select(this)
+                        d3.select(this).selectAll("rect")
                             .style('fill', d.fill)
                             .style("cursor", "default");
+                        d3.select(this).selectAll("text")
+                            .style('display', 'none');
+                        d3.selectAll("#arg_${divnum} .endpoints")
+                            .style('display', 'block');
                         d3.selectAll("#arg_${divnum} .link")
                             .style("stroke", function(d) {
                                 return d.stroke;


### PR DESCRIPTION
Major functionality to show positions on the genome bar, stacked onto #145:

Mousing over a region in the genome bar show the left and right of the region (and hides the whole-bar endpoints):

<img width="599" alt="Screenshot 2025-02-27 at 10 45 53" src="https://github.com/user-attachments/assets/e8dc13c3-8ed2-484b-abbf-6ea109887683" />

Mousing over an edge shows the mutations on that edge and the right and left positions of the edge bounds (is it weird that the mutation positions are centred, but the region poisons are left / right aligned?)

<img width="593" alt="Screenshot 2025-02-27 at 10 48 09" src="https://github.com/user-attachments/assets/527c4eca-8957-44a7-845f-51f0e5af589d" />
