### PR TITLE
Put all templated variables into the core call

### DIFF
--- a/example.py
+++ b/example.py
@@ -38,5 +38,7 @@ d3arg = tskit_arg_visualizer.D3ARG.from_ts(ts=ts, progress=True)
 d3arg.draw_node(
     node=20,
     degree=5,
-    rotate_tip_labels=True
+    rotate_tip_labels=True,
+    show_mutations=True,
+    condense_mutations=True
 )


### PR DESCRIPTION
This just reworks the javascript so that all the templated variables are in a single call (i.e. the "$" sign only appears in the final function). This fixes #143 and also should make it easier to remove multiple imports of the same code in the future.