### PR TITLE
Separate templates

### DIFF
--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -1253,18 +1253,4 @@ function main_visualizer(
     }
 
     draw_force_diagram()
-}
-
-/* NB: the code below fires up the visualizer: templates in this call
-    can be used to pass in the appropriate data
-*/
-
-ensureRequire()
-    .then(require => {
-        require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
-        require(["d3"], function(d3) {
-            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $include_mutation_labels, $tree_highlighting, "$title", $rotate_tip_labels, "$plot_type", "$source")
-        });
-    })
-    .catch(err => console.error('Failed to load require.js:', err));
-
+};


### PR DESCRIPTION
Separate out the js & css code which is common to all visualizer instances.

This means it should be possible to figure out how to inject the `common_header` text into the header of e.g. a Jupyter notebook, and therefore avoid saving the entire codebase in every visualiser cell.

Stacked onto #168 for simplicity.