### PR TITLE
Add an HTML "preamble"

### DIFF
--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -895,6 +895,7 @@ class D3ARG:
             label_mutations=False,
             condense_mutations=True,
             rotate_tip_labels=False,
+            preamble=None,
         ):
         """Creates the required JSON for both draw() and draw_node()
 
@@ -951,6 +952,8 @@ class D3ARG:
             Whether to add the full label (position_index:inherited:derived) for each mutation. (default=False)
         rotate_tip_labels : bool
             Rotates tip labels by 90 degrees. (default=False)
+        preamble : str
+            The preamble. (default="")
             
         Returns
         -------
@@ -962,6 +965,8 @@ class D3ARG:
         if title is not None:
             title = str(title)
             y_shift = 100
+        if preamble is not None:
+            preamble = str(preamble)
         if not show_mutations:
             tick_times = nodes["time"]
         elif ignore_mutation_times:
@@ -1191,6 +1196,7 @@ class D3ARG:
             "plot_type": str(plot_type),
             "default_node_style": self.default_node_style,
             "title": title,
+            "preamble": preamble,
         }
         return arg
 
@@ -1312,6 +1318,7 @@ class D3ARG:
             rotate_tip_labels=False,
             zoom=0,
             styles=None,
+            preamble=None,
         ):
         """Draws the D3ARG using D3.js by sending a custom JSON object to visualizer.js 
 
@@ -1368,6 +1375,14 @@ class D3ARG:
             For example, [".labels {font-family: Times}"] will change the font of all the
             labels. Note that some styles are set from values in the dataframes stored in the
             D3ARG object, and cannot be altered using the 'styles' parameter. (default=None)
+        preamble : str
+            Extra HTML to be added to the D3ARG visualization. It is the user's
+            responsibility to ensure that this is valid HTML. The preamble can be used
+            to add additional information, such as a legend, to the visualization. To
+            overlay any content on top of the plot, you may wish to wrap the preamble in a
+            tag which has the "position: absolute" and "z-index: 1" styles set, e.g.
+            `preamble='<div style="position:absolute; z-index:1; right:2em">My text</div>'`
+            (default="")
         """
         
         if condense_mutations:
@@ -1398,6 +1413,7 @@ class D3ARG:
             label_mutations=label_mutations,
             condense_mutations=condense_mutations,
             rotate_tip_labels=rotate_tip_labels,
+            preamble=preamble,
         )
         draw_D3(arg_json=arg, styles=styles, force_notebook=force_notebook)
 
@@ -1544,6 +1560,7 @@ class D3ARG:
             force_notebook=False,
             rotate_tip_labels=False,
             styles=None,
+            preamble=None,
         ):
         """Draws a subgraph of the D3ARG using D3.js by sending a custom JSON object to visualizer.js
 
@@ -1594,6 +1611,14 @@ class D3ARG:
             For example, [".labels {font-family: Times}"] will change the font of all the
             labels. Note that some styles are set from values in the dataframes stored in the
             D3ARG object, and cannot be altered using the 'styles' parameter. (default=None)
+        preamble : str
+            Extra HTML to be added to the D3ARG visualization. It is the user's
+            responsibility to ensure that this is valid HTML. The preamble can be used
+            to add additional information, such as a legend, to the visualization. To
+            overlay any content on top of the plot, you may wish to wrap the preamble in a
+            tag which has the "position: absolute" and "z-index: 1" styles set, e.g.
+            `preamble='<div style="position:absolute; z-index:1; right:2em">My text</div>'`
+            (default="")
         """
 
         if condense_mutations:
@@ -1618,7 +1643,8 @@ class D3ARG:
             ignore_mutation_times=ignore_mutation_times,
             label_mutations=label_mutations,
             condense_mutations=condense_mutations,
-            rotate_tip_labels=rotate_tip_labels
+            rotate_tip_labels=rotate_tip_labels,
+            preamble=preamble,
         )
         draw_D3(arg_json=arg, styles=styles, force_notebook=force_notebook)
         if return_included_nodes:

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -28,6 +28,7 @@ function main_visualizer(
     title,
     rotate_tip_labels,
     plot_type,
+    preamble,
     source
 ) {
     /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
@@ -170,6 +171,9 @@ function main_visualizer(
     function draw_force_diagram() {
         var evenly_distributed_positions = graph.evenly_distributed_positions;
         var div_selector = "#arg_" + String(divnum);
+        if (preamble) {
+            d3.select(div_selector).html(preamble);
+        }
         var tip = d3.select(div_selector).append("div")
             .attr("class", "tooltip")
             .style("display", "none");
@@ -1345,7 +1349,7 @@ ensureRequire()
     .then(require => {
         require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
         require(["d3"], function(d3) {
-            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $label_mutations, $tree_highlighting, $title, $rotate_tip_labels, $plot_type, $source)
+            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $label_mutations, $tree_highlighting, $title, $rotate_tip_labels, $plot_type, $preamble, $source)
         });
     })
     .catch(err => console.error('Failed to load require.js:', err));


### PR DESCRIPTION
This is a bit of a minor one, but it is often useful to annotate plots e.g. with legends or explanatory text. In `ts.draw_svg()` we have just introduced a `preamble` parameter, which can be used to insert SVG text before the plot itself. That means we don't need to design a legend function outselves, but can do so later, and pass it in to the preamble. Here's a PR to do the same in the D3ARG, only it would be raw HTML that's injected (and the user would have to take responsibility for it being properly formed). 

What do you think @kitchensjn ? Does this seem OK. It would be very useful for me to be able to add html like this to produce notebook outputs for use as supplementary material in the Covid paper.