### PR TITLE
Change to json.dumps() for escaping

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -74,7 +74,10 @@ def draw(
     ignore_mutation_times=True,
     label_mutations=False,
     condense_mutations=False,
-    force_notebook=False
+    force_notebook=False,
+    rotate_tip_labels=False,
+    zoom=0,
+    styles=None,
 ):
 """Draws the D3ARG using D3.js by sending a custom JSON object to visualizer.js 
 
@@ -87,8 +90,10 @@ height : int
 tree_highlighting : bool
     Include the interactive chromosome at the bottom of the figure to
     to let users highlight trees in the ARG (default=True)
-y_axis_labels : bool
-    Includes labelled y-axis on the left of the figure (default=True)
+y_axis_labels : bool, list, or dict
+    Whether to include the y-axis on the left of the figure. By default, tick marks will be automatically
+    chosen. You can specify a list of tick marks to use instead. You can also set custom text for tick marks
+    using a dictionary where key is the time and value is the text. (default=True)
 y_axis_scale : string
     Scale used for the positioning nodes along the y-axis. Options:
         "rank" (default) - equal vertical spacing between nodes
@@ -114,11 +119,21 @@ show_mutations : bool
 ignore_mutation_times : bool
     Whether to plot mutations evenly on edge (True) or at there specified times (False). (default=True, ignored)
 label_mutations : bool
-    Whether to add the full label (inherited_state + position + derived_state) for each mutation. (default=False)
+    Whether to add the full label (position_index:inherited:derived) for each mutation. (default=False)
 condense_mutations : bool
     Whether to merge all mutations along an edge into a single mutation symbol. (default=False)
 force_notebook : bool
     Forces the the visualizer to display as a notebook. Possibly necessary for untested environments. (default=False)
+rotate_tip_labels : bool
+    Rotates tip labels by 90 degrees. (default=False)
+zoom : int
+    The level of detail that you want. Larger numbers equate to less detail/more collapsing
+styles : list
+    A list of css strings, one per selector. The ID of the current drawing will be
+    appended to each string, so that the styles are unique to the current drawing.
+    For example, [".labels {font-family: Times}"] will change the font of all the
+    labels. Note that some styles are set from values in the dataframes stored in the
+    D3ARG object, and cannot be altered using the 'styles' parameter. (default=None)
 """
 ```
 
@@ -138,7 +153,7 @@ This function is very similar to the standard `draw()`, but you need to provide 
 ```
 def draw_node(
     self,
-    node,
+    seed_nodes,
     width=500,
     height=500,
     depth=1,
@@ -151,14 +166,16 @@ def draw_node(
     label_mutations=False,
     condense_mutations=False,
     return_included_nodes=False,
-    force_notebook=False
+    force_notebook=False,
+    rotate_tip_labels=False,
+    styles=None,
 ):
 """Draws a subgraph of the D3ARG using D3.js by sending a custom JSON object to visualizer.js
 
 Parameters
 ----------
-node : int
-    Node ID that will be central to the subgraph
+seed_nodes : int or list
+    Node ID or list of node IDs that will be central to the subgraph
 width : int
     Width of the force layout graph plot in pixels (default=500)
 height : int
@@ -168,8 +185,10 @@ depth : int or list(int, int)
     node to include in the subgraph (default=1). If this is a list, the
     number of nodes above is taken from the first element and
     the number of nodes below from the last element.
-y_axis_labels : bool
-    Includes labelled y-axis on the left of the figure (default=True)
+y_axis_labels : bool, list, or dict
+    Whether to include the y-axis on the left of the figure. By default, tick marks will be automatically
+    chosen. You can specify a list of tick marks to use instead. You can also set custom text for tick marks
+    using a dictionary where key is the time and value is the text. (default=True)
 y_axis_scale : string
     Scale used for the positioning nodes along the y-axis. Options:
         "rank" (default) - equal vertical spacing between nodes
@@ -185,13 +204,21 @@ show_mutations : bool
 ignore_mutation_times : bool
     Whether to plot mutations evenly on edge (True) or at there specified times (False). (default=True, ignored)
 label_mutations : bool
-    Whether to add the full label (position_index:ancestral:derived) for each mutation. (default=False)
+    Whether to add the full label (position_index:inherited:derived) for each mutation. (default=False)
 condense_mutations : bool
     Whether to merge all mutations along an edge into a single mutation symbol. (default=False)
 return_included_nodes : bool
     Returns a list of nodes plotted in the subgraph. (default=False)
 force_notebook : bool
     Forces the the visualizer to display as a notebook. Possibly necessary for untested environments. (default=False)
+rotate_tip_labels : bool
+    Rotates tip labels by 90 degrees. (default=False)
+styles : list
+    A list of css strings, one per selector. The ID of the current drawing will be
+    appended to each string, so that the styles are unique to the current drawing.
+    For example, [".labels {font-family: Times}"] will change the font of all the
+    labels. Note that some styles are set from values in the dataframes stored in the
+    D3ARG object, and cannot be altered using the 'styles' parameter. (default=None)
 """
 ```
 

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -1,5 +1,6 @@
 import collections
 import itertools
+import json
 import math
 import operator
 import os
@@ -128,13 +129,14 @@ def convert_time_to_position(t, min_time, max_time, scale, unique_times, h_spaci
 
 
 def draw_D3(arg_json, styles=None, force_notebook=False):
-    arg_json["source"] = arg_json.copy()
+    arg_json = {k: json.dumps(v) for k, v in arg_json.items()}
+    arg_json["source"] = json.dumps(arg_json.copy())
     arg_json["divnum"] = str(random.randint(0,9999999999))
     arg_id = "arg_" + arg_json['divnum']
     JS_text = Template((
         '<div id="{}" class="d3arg" style="min-width:{}px; min-height:{}px;"></div>'
         '<script>$main_text</script>'
-    ).format(arg_id, arg_json["width"]+40, arg_json["height"]+80))
+    ).format(arg_id, float(arg_json["width"]) + 40, float(arg_json["height"]) + 80))
     visualizerjs = open(os.path.dirname(__file__) + "/visualizer.js", "r")
     main_text_template = Template(visualizerjs.read())
     visualizerjs.close()
@@ -886,7 +888,7 @@ class D3ARG:
             ignore_mutation_times=True,
             label_mutations=False,
             condense_mutations=True,
-            rotate_tip_labels=False
+            rotate_tip_labels=False,
         ):
         """Creates the required JSON for both draw() and draw_node()
 
@@ -951,9 +953,9 @@ class D3ARG:
         """
 
         y_shift = 50
-        if title:
+        if title is not None:
+            title = str(title)
             y_shift = 100
-
         if not show_mutations:
             tick_times = nodes["time"]
         elif ignore_mutation_times:
@@ -1149,38 +1151,38 @@ class D3ARG:
 
         if tree_highlighting:
             height += 75
-        if title:
+        if title is not None:
             height += 50
 
         arg = {
             "data":{
-                "nodes":transformed_nodes,
-                "links":edges.to_dict("records"),
-                "mutations":transformed_muts,
-                "breakpoints":transformed_bps,
-                "evenly_distributed_positions":sample_positions,
+                "nodes": transformed_nodes,
+                "links": edges.to_dict("records"),
+                "mutations": transformed_muts,
+                "breakpoints": transformed_bps,
+                "evenly_distributed_positions": sample_positions,
             },
-            "width":width,
-            "height":height,
+            "width": width,
+            "height": height,
             "y_axis":{
                 "include_labels":str(shift_for_y_axis).lower(),
-                "ticks":list(y_axis_final.keys()),
-                "text":list(y_axis_final.values()),
-                "max_min":[max(y_axis_final.keys()),min(y_axis_final.keys())],
-                "scale":y_axis_scale,
+                "ticks": list(y_axis_final.keys()),
+                "text": list(y_axis_final.values()),
+                "max_min": [max(y_axis_final.keys()),min(y_axis_final.keys())],
+                "scale": str(y_axis_scale),
             },
             "edges":{
-                "type":edge_type,
-                "variable_width":str(bool(variable_edge_width)).lower(),
-                "include_underlink":str(bool(include_underlink)).lower()
+                "type": str(edge_type),
+                "variable_width": bool(variable_edge_width),
+                "include_underlink": bool(include_underlink)
             },
-            "condense_mutations":str(bool(condense_mutations)).lower(),
-            "label_mutations":str(bool(label_mutations)).lower(),
-            "tree_highlighting":str(bool(tree_highlighting)).lower(),
-            "title":str(title).replace("\n", "\\n"),
-            "rotate_tip_labels":str(bool(rotate_tip_labels)).lower(),
-            "plot_type":plot_type,
-            "default_node_style":self.default_node_style
+            "condense_mutations": bool(condense_mutations),
+            "label_mutations": bool(label_mutations),
+            "tree_highlighting": bool(tree_highlighting),
+            "rotate_tip_labels": bool(rotate_tip_labels),
+            "plot_type": str(plot_type),
+            "default_node_style": self.default_node_style,
+            "title": title,
         }
         return arg
 
@@ -1387,7 +1389,7 @@ class D3ARG:
             ignore_mutation_times=ignore_mutation_times,
             label_mutations=label_mutations,
             condense_mutations=condense_mutations,
-            rotate_tip_labels=rotate_tip_labels
+            rotate_tip_labels=rotate_tip_labels,
         )
         draw_D3(arg_json=arg, styles=styles, force_notebook=force_notebook)
 

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -1391,12 +1391,12 @@ class D3ARG:
         )
         draw_D3(arg_json=arg, styles=styles, force_notebook=force_notebook)
 
-    def subset_graph(self, node, depth):
+    def subset_graph(self, seed_nodes, depth):
         """Subsets the graph to focus around a specific node
 
         Parameters
         ----------
-        node : int or list
+        seed_nodes : int or list
             Node ID or list of node IDs that will be central to the subgraph
         depth : int or list(int, int)
             Number of nodes above (older than) and below (younger than) the central
@@ -1416,9 +1416,9 @@ class D3ARG:
             The breakpoints to be plotted, potentially subset of original graph
         """
 
-        if type(node) == int:
-            node = [node]
-        for n in node:
+        if type(seed_nodes) == int:
+            seed_nodes = [seed_nodes]
+        for n in seed_nodes:
             if n not in self.nodes.id.values:
                 raise ValueError(f"Node '{n}' not in the graph.")
 
@@ -1427,13 +1427,13 @@ class D3ARG:
         older_depth = depth[0]
         younger_depth = depth[-1]
 
-        node_set = set(node)
+        node_set = set(seed_nodes)
         first = True
 
         # Inefficient loop, doesn't acknowledge that some edges could be shared
         # between focal nodes. These duplicates are dropped eventually, but
         # a better function would not add them to start.
-        for focal in node:
+        for focal in seed_nodes:
             
             above = {focal}
             below = {focal}
@@ -1518,7 +1518,7 @@ class D3ARG:
 
     def draw_node(
             self,
-            node,   # may want to change this parameter name if it's confusing that it can take multiple nodes.
+            seed_nodes,
             width=500,
             height=500,
             depth=1,
@@ -1539,7 +1539,7 @@ class D3ARG:
 
         Parameters
         ----------
-        node : int or list
+        seed_nodes : int or list
             Node ID or list of node IDs that will be central to the subgraph
         width : int
             Width of the force layout graph plot in pixels (default=500)
@@ -1591,7 +1591,7 @@ class D3ARG:
                 print("WARNING: `condense_mutations=True` forces `ignore_mutation_times=True`.")
                 ignore_mutation_times = True
 
-        included = self.subset_graph(node=node, depth=depth)
+        included = self.subset_graph(seed_nodes=seed_nodes, depth=depth)
         arg = self._prepare_json(
             plot_type="node",
             nodes=included.nodes,

--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -139,7 +139,6 @@ def draw_D3(arg_json, styles=None, force_notebook=False):
         '<div id="{}" class="d3arg" style="min-width:{}px; min-height:{}px;"></div>'
         '<script>$main_text</script>'
     ).format(arg_id, float(arg_json["width"]) + 40, float(arg_json["height"]) + 80))
-    ).format(arg_id, float(arg_json["width"]) + 40, float(arg_json["height"]) + 80))
     visualizerjs = open(os.path.dirname(__file__) + "/visualizer.js", "r")
     main_text_template = Template(visualizerjs.read())
     visualizerjs.close()

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -172,7 +172,7 @@ function main_visualizer(
         console.log(title);
         
         var evenly_distributed_positions = graph.evenly_distributed_positions;
-        var div_selector = "#arg_" + String(divnum)
+        var div_selector = "#arg_" + String(divnum);
         var tip = d3.select(div_selector).append("div")
             .attr("class", "tooltip")
             .style("display", "none");
@@ -1253,7 +1253,7 @@ ensureRequire()
     .then(require => {
         require.config({ paths: {d3: 'https://d3js.org/d3.v7.min'}});
         require(["d3"], function(d3) {
-            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $label_mutations, $tree_highlighting, "$title", $rotate_tip_labels, "$plot_type", "$source")
+            main_visualizer(d3, $divnum, $data, $width, $height, $y_axis, $edges, $condense_mutations, $label_mutations, $tree_highlighting, $title, $rotate_tip_labels, $plot_type, $source)
         });
     })
     .catch(err => console.error('Failed to load require.js:', err));


### PR DESCRIPTION
I'm pretty sure this is what we should be doing (using `json.dumps()` to escape the stuff we are Templating into the javascript. This makes the whole thing a lot less fragile.

However, this is breaking the "download JSON" part of the visualizer. Could you possibly take a looks to see how we could fix it @kitchensjn ? I suspect it;s just that we no longer need to do manual escaping of the source string around line 196 of visualizer.js?