### PR TITLE
Remove most `eval` statements

### DIFF
--- a/tskit_arg_visualizer/__init__.py
+++ b/tskit_arg_visualizer/__init__.py
@@ -1152,7 +1152,7 @@ class D3ARG:
                                 "x_pos": list(x_pos),
                                 "fill": default_mutation_styles["condensed"]["fill"],
                                 "stroke": default_mutation_styles["condensed"]["stroke"],
-                                "active": "false",
+                                "active": False,
                                 "label": "⨉"+str(muts.shape[0]),
                                 "content": "<br>".join(muts.content),
                                 "size": size,
@@ -1185,7 +1185,7 @@ class D3ARG:
                                     "derived": mut.derived,
                                     "fill": mut.fill,
                                     "stroke": mut.stroke,
-                                    "active": "false",
+                                    "active": False,
                                     "label": label,
                                     "content": content,
                                     "size": mut['size'],  # can't use attribute access as "size" already exists
@@ -1228,7 +1228,7 @@ class D3ARG:
         transformed_bps = breakpoints.loc[:,:]
         transformed_bps["x_pos"] = transformed_bps["x_pos_01"] * width + y_axis_left_spacing
         transformed_bps["width"] = transformed_bps["width_01"] * width
-        transformed_bps["included"] = "true"
+        transformed_bps["included"] = True
         transformed_bps = transformed_bps.to_dict("records")
 
         if shift_for_y_axis:
@@ -1606,7 +1606,7 @@ class D3ARG:
             if j == 0:
                 current_region = bp
             important_bp = False
-            bp["included"] = "false"
+            bp["included"] = False
             for i,edge in included_edges.iterrows():
                 bounds = edge["bounds"].split(" ")
                 for b in bounds:
@@ -1615,10 +1615,10 @@ class D3ARG:
                     stop = float(b[1])
                     # assumes edge lengths are always larger than breakpoints which should be true here
                     if (start <= bp["start"]) and (stop >= bp["stop"]):
-                        bp["included"] = "true"
+                        bp["included"] = True
                     if (start == bp["start"]) or (stop == bp["start"]):
                         important_bp = True
-            if (bp["included"] == "false") and (current_region["included"] == "true"):
+            if (not bp["included"]) and current_region["included"]:
                 important_bp = True
             if j > 0:
                 if important_bp:
@@ -1791,7 +1791,7 @@ class D3ARG:
         transformed_bps = self.breakpoints.loc[:,:]
         transformed_bps["x_pos"] = transformed_bps["x_pos_01"] * width
         transformed_bps["width"] = transformed_bps["width_01"] * width
-        transformed_bps["included"] = "true"
+        transformed_bps["included"] = True
         transformed_bps = transformed_bps.to_dict("records")
 
         start = float(self.breakpoints["start"].min())

--- a/tskit_arg_visualizer/visualizer.js
+++ b/tskit_arg_visualizer/visualizer.js
@@ -624,7 +624,7 @@ function main_visualizer(
             })
             .on("mouseout", function(event, d) {
                 if (!d3.select(div_selector + ">svg").classed("no-hover")) {
-                    if (!eval(d.active)) {
+                    if (!d.active) {
                         d3.select(this).style("cursor", "default");
                         if (condense_mutations) {
                             d.mutation_id.forEach((id, i) => dehighlight_mut(id, d.site_id[i]));
@@ -632,7 +632,7 @@ function main_visualizer(
                             dehighlight_mut(d.mutation_id, d.site_id);
                         }
                     }
-                    if (!eval(d.active)) {
+                    if (!d.active) {
                         d3.select(this).style("cursor", "default");
                         if (condense_mutations) {
                             d.mutation_id.forEach((id, i) => dehighlight_mut(id, d.site_id[i]));
@@ -1174,7 +1174,7 @@ function main_visualizer(
                 .data(graph.breakpoints)
                 .enter()
                 .append("g")
-                .attr("class", d => eval(d.included) ? "included" : null)
+                .attr("class", d => (d.included) ? "included" : null)
                 .attr("start", d => d.start)
                 .attr("stop", d => d.stop);
 
@@ -1186,7 +1186,7 @@ function main_visualizer(
                 .attr("height", 40)
                 .attr("stroke", "#FFFFFF")
                 .attr("stroke-width", 1)
-                .attr("fill", d => eval(d.included) ? d.fill : "gray");
+                .attr("fill", d => (d.included) ? d.fill : "gray");
 
             breakpoint_regions
                 .append("text")
@@ -1207,7 +1207,7 @@ function main_visualizer(
             breakpoint_regions
                 .on('mouseover', function (event, d) {
                     if (!d3.select(div_selector + ">svg").classed("no-hover")) {
-                        if (eval(d.included)) {
+                        if (d.included) {
                             d3.select(this).selectAll("rect")
                                 .style('fill', '#1eebb1')
                                 .style("cursor", "pointer");
@@ -1232,7 +1232,7 @@ function main_visualizer(
                 })
                 .on('mouseout', function (event, d) {
                     if (!d3.select(div_selector + ">svg").classed("no-hover")) {
-                        if (eval(d.included)) {
+                        if (d.included) {
                             d3.select(this).selectAll("rect")
                                 .style('fill', d.fill)
                                 .style("cursor", "default");


### PR DESCRIPTION
Fixes #228 

We can't remove the one that changes `"d3.symbolCircle"` into `d3.symbolCircle(size)` though, so there's still one `eval` left.

This seems to work OK for me in my limited testing. Do you think you could check @kitchensjn ?