### PR TITLE
Add notebook anywidget support via D3ARG.to_anywidget()

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,12 @@ name: tsviz
 channels:
   - conda-forge
 dependencies:
-  - python=3.13.0
+  - python>=3.8
   - pip
   - jupyterlab
   - pandas
   - msprime
   - IPython
   - tqdm
+  - anywidget
   - tszip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,20 +11,23 @@ keywords = [
     "visualization",
     "D3.js",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "pandas",
     "msprime",
     "IPython",
-    "tqdm"
+    "tqdm",
+    "anywidget"
 ]
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "License :: OSI Approved :: MIT License",
     "Development Status :: 3 - Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 msprime
 IPython
 tqdm
+anywidget


### PR DESCRIPTION
## Summary

  This PR adds D3ARG.to_anywidget(...) to render ARG visualizations as an anywidget object in notebook environments (e.g.  marimo).

  ## What changed

  - Added to_anywidget() to D3ARG in tskit_arg_visualizer/__init__.py.
  - Reused existing visualizer.js + visualizer.css rendering path by generating srcdoc for an iframe-based anywidget.
  - Added anywidget dependency in:
      - requirements.txt
      - environment.yml
      - pyproject.toml
  - Updated Python metadata for dependency compatibility:
      - pyproject.toml: requires-python = ">=3.8"
      - environment.yml: python>=3.8
      - Classifiers now include 3.8 through 3.13

  ## marimo rendering fix

  - Added base iframe styles (margin:0, overflow:hidden, box-sizing:border-box) to avoid inner overflow and duplicate-looking horizontal scrollbars.

  ## Validation

  - Internal smoke test: created D3ARG from msprime output and called to_anywidget(...).
  - Verified widget object is returned with non-empty srcdoc and expected frame dimensions.